### PR TITLE
Convert "entries" and "status" from global variables to class members.

### DIFF
--- a/KeepassReader.py
+++ b/KeepassReader.py
@@ -13,9 +13,9 @@ from KeepassDatabase import KeepassDatabase
 
 
 class KeepassReader(object):
-	entries = []
-
-	status = {'error': 0}
+	def __init__(self):
+		self.entries = []
+		self.status = {'error': 0}
 
 	# Open the filename and password
 	# ----------------------------------------------------------------------------


### PR DESCRIPTION
This way it is possible to have several instances of the class KeepassReader that don't interfere with each other.